### PR TITLE
Rename copied design document

### DIFF
--- a/setup_wizard.py
+++ b/setup_wizard.py
@@ -246,7 +246,12 @@ class SetupWizardGUI:
         if design_provided:
             if design_path is None:
                 design_path = project_dir / "design.md"
-            create_file(project_dir / design_path.name, Path(design_path).read_text() if design_path.exists() else "")
+            # Always rename the copied design document to "design.md" inside the
+            # new project regardless of the original file name.
+            create_file(
+                project_dir / "design.md",
+                Path(design_path).read_text() if design_path.exists() else "",
+            )
         else:
             create_file(project_dir / "design.md", _empty_design(name))
 


### PR DESCRIPTION
## Summary
- always save copied design docs as `design.md` to ensure consistent naming

## Testing
- `python3 -m py_compile setup_wizard.py`


------
https://chatgpt.com/codex/tasks/task_e_68723667b91c8332a8cbd17a7e41345c